### PR TITLE
Fix classification of Adblock filter files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,15 @@
+[attr]adb linguist-detectable linguist-language=AdBlock
+
+adblocker adb
+allowlist adb
+blocklist adb
+checkallow adb
+checkblock adb
+customallowlist adb
+customblocklist adb
+domain adb
+host adb
+lite_adblocker adb
+lite_domain adb
+lite_host adb
+title adb


### PR DESCRIPTION
This pull-request fixes the syntax highlighting and language classification of this project's filter-list files, which are currently unrecognised by GitHub.